### PR TITLE
[1.1.0] - Melhorias nos tipos de exceções e métodos de suporte

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+Mudanças relevantes no pacote serão documentadas neste arquivo.
+
+## 1.1.0 - 21 de setembro de 2023
+
+- Os métodos `make()` e `toFormat()` da classe `Handler` agora lançam `LogicException` quando não há nenhum arquivo selecionado.
+- O método `use()` agora lança `OutOfRangeException` quando o índice selecionado é inexistente.
+- Foram adicionados os métodos `first`, `last` e `exists` à classe `Handler`.
+- Agora a classe `FileFormatFactory` conta com constantes de suporte para identificar tipos MIME.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ formato ZIP.
 
 ## Requerimentos
 
-- PHP >=7.2.5 e <8.0.0. **Suporte ao PHP 8 será adicionado na versão 2.x.**
+- PHP >=7.2.5.
 - [PHP extensão ZIP](https://www.php.net/manual/pt_BR/zip.installation.php)
 - [PHP extensão Mbstring](https://www.php.net/manual/pt_BR/mbstring.installation.php)
 
@@ -26,8 +26,9 @@ Exemplo com o formato da API do banco Sicoob, que tem um campo 'resultado' e um 
 que está codificado em formato base64. O arquivo que está dentro do ZIP é um JSON:
 
 ```php
-  use \Vini\ZipReturnParser\Handler;
-  use \Vini\ZipReturnParser\Responses\Sicoob;
+  use Vini\ZipReturnParser\Handler;
+  use Vini\ZipReturnParser\Responses\Sicoob;
+  use Vini\ZipReturnParser\Factories\FileFormatFactory;
   
   // ... busca o arquivo na API do banco: $respostaApi
   
@@ -41,7 +42,7 @@ que está codificado em formato base64. O arquivo que está dentro do ZIP é um 
   $handler->fromBase64($response->arquivo)->make();
 
   // Usa o primeiro arquivo e cria uma instância da classe que trata JSON automaticamente
-  $file = $handler->use(0)->toFormat();
+  $file = $handler->first()->toFormat(FileFormatFactory::FORMAT_JSON);
 
   // Imprime na tela o conteúdo do arquivo (nesse passo qualquer outro processamento pode ser feito)
   var_dump($file->getDecoded());

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ formato ZIP.
 
 ## Requerimentos
 
-- PHP 7.0 ou mais recente.
+- PHP >=7.2.5 e <8.0.0. **Suporte ao PHP 8 será adicionado na versão 2.x.**
 - [PHP extensão ZIP](https://www.php.net/manual/pt_BR/zip.installation.php)
 - [PHP extensão Mbstring](https://www.php.net/manual/pt_BR/mbstring.installation.php)
 

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": "^7.2.5",
+        "php": "^7.2.5|^8.0",
         "ext-zip": "*",
         "ext-mbstring": "*",
         "nesbot/carbon": "^2.0"

--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,6 @@
     "scripts": {
         "test": "vendor/bin/phpunit --testdox",
         "fix-style": "php-cs-fixer fix ./src --diff",
-        "static-analyze": "psalm --threads=8 --diff --php-version=7.0"
+        "static-analyze": "psalm --threads=8 --diff --php-version=7.2.5"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": ">=7.0",
+        "php": "^7.2.5",
         "ext-zip": "*",
         "ext-mbstring": "*",
         "nesbot/carbon": "^2.0"

--- a/src/Factories/FileFormatFactory.php
+++ b/src/Factories/FileFormatFactory.php
@@ -18,7 +18,7 @@ class FileFormatFactory
      *
      * @param string $format
      *
-     * @throws InvalidArgumentException
+     * @throws DomainException
      */
     public static function create(
         string $format = 'application/json',

--- a/src/Factories/FileFormatFactory.php
+++ b/src/Factories/FileFormatFactory.php
@@ -13,22 +13,24 @@ use DomainException;
  */
 class FileFormatFactory
 {
-    /**
-     * Retorna a classe de tratamento do formato de arquivo.
-     *
-     * @param string $format
-     *
-     * @throws DomainException
-     */
-    public static function create(
-        string $format = 'application/json',
-        string $data
-    ): Json {
-        switch ($format) {
+  public const FORMAT_JSON = 'application/json';
+
+  /**
+   * Retorna a classe de tratamento do formato de arquivo.
+   *
+   * @param string $format
+   *
+   * @throws DomainException
+   */
+  public static function create(
+    string $format = 'application/json',
+    string $data
+  ): Json {
+    switch ($format) {
       case 'application/json':
         return new Json($data);
       default:
         throw new DomainException('Tipo de arquivo não suportado.');
     }
-    }
+  }
 }

--- a/src/Factories/FileFormatFactory.php
+++ b/src/Factories/FileFormatFactory.php
@@ -3,7 +3,7 @@
 namespace Vini\ZipReturnParser\Factories;
 
 use Vini\ZipReturnParser\Formats\Json;
-use InvalidArgumentException;
+use DomainException;
 
 /**
  * Classe responsável por retornar instâncias apropriadas para tratar cada
@@ -28,7 +28,7 @@ class FileFormatFactory
       case 'application/json':
         return new Json($data);
       default:
-        throw new InvalidArgumentException('Tipo de arquivo não suportado.');
+        throw new DomainException('Tipo de arquivo não suportado.');
     }
     }
 }

--- a/src/Formats/Json.php
+++ b/src/Formats/Json.php
@@ -7,12 +7,12 @@ namespace Vini\ZipReturnParser\Formats;
  */
 class Json extends AbstractFormat
 {
-  /**
-   * Retorna os dados codificados em uma string JSON ou false em caso de erro
-   *
-   * @param boolean $escape
-   * @return string|false
-   */
+    /**
+     * Retorna os dados codificados em uma string JSON ou false em caso de erro
+     *
+     * @param boolean $escape
+     * @return string|false
+     */
     public function getEncoded()
     {
         return json_encode($this->utf8($this->data));

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -157,10 +157,13 @@ class Handler
     public function toFormat($format = null)
     {
         if (!empty($this->current)) {
+
+            $file = $this->temporaryFile ?? $this->base64TemporaryFile;
+
+            $filepath = 'zip://' . $file . '#' . $this->current;
+
             // Verifica o tipo MIME do arquivo. Caso não haja arquivo comum, usa o base 64.
-            $mime = mime_content_type(
-                'zip://' . $this->temporaryFile ?? $this->base64TemporaryFile . '#' . $this->current
-            );
+            $mime = mime_content_type($filepath);
 
             return FileFormatFactory::create($format ?? $mime, $this->currentData);
         }

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -10,7 +10,7 @@ use ZipArchive;
 
 /**
  * Classe responsável por fazer o tratamento do arquivo em formato ZIP
- * 
+ *
  * @package ViniFranco\ZipReturnParser
  * @author Vini Franco <email@vinifranco.com.br>
  */
@@ -65,9 +65,9 @@ class Handler
     public function fromBase64($base64)
     {
         $temporaryFileName =
-      'zip-return-parser-' .
-      Carbon::now('America/Fortaleza')->getTimestamp() .
-      '.zip';
+            'zip-return-parser-' .
+            Carbon::now('America/Fortaleza')->getTimestamp() .
+            '.zip';
 
         // Salva o conteúdo em um arquivo temporário
         $temporary = sys_get_temp_dir() . DIRECTORY_SEPARATOR . $temporaryFileName;
@@ -91,9 +91,9 @@ class Handler
     {
         // Gera um nome de arquivo temporário
         $temporaryFileName =
-      'zip-return-parser-' .
-      Carbon::now('America/Fortaleza')->getTimestamp() .
-      '.zip';
+            'zip-return-parser-' .
+            Carbon::now('America/Fortaleza')->getTimestamp() .
+            '.zip';
 
         // Salva o conteúdo em um arquivo temporário
         $temporary = sys_get_temp_dir() . DIRECTORY_SEPARATOR . $temporaryFileName;
@@ -109,7 +109,7 @@ class Handler
 
     /**
      * Abre o arquivo ZIP temporário.
-     * 
+     *
      * @throws LogicException Caso não haja nenhum arquivo adicionado.
      */
     public function make(): self
@@ -137,10 +137,10 @@ class Handler
         if ($this->exists($index)) {
             // Define o nome do arquivo sendo usado.
             $this->current = $this->archive->getNameIndex($index);
-            
+
             // Puxa o conteúdo do arquivo.
             $this->currentData = $this->archive->getFromIndex($index);
-            
+
             return $this;
         }
 
@@ -194,7 +194,7 @@ class Handler
     /**
      * Retorna o caminho para o arquivo temporário gerado
      * a partir da string de dados bruta.
-     * 
+     *
      * @return string
      */
     public function getTemporaryFilePath()
@@ -205,7 +205,7 @@ class Handler
     /**
      * Retorna o caminho para o arquivo temporário gerado a partir
      * da string base64 do arquivo ZIP.
-     * 
+     *
      * @return string
      */
     public function getBase64TemporaryFilePath()

--- a/tests/Unit/JsonTest.php
+++ b/tests/Unit/JsonTest.php
@@ -9,55 +9,25 @@ use PHPUnit\Framework\TestCase;
 
 class Json extends TestCase
 {
-  public function testJson()
+  /**
+   * Conteúdo de um arquivo zipado de teste, codificado em base64.
+   *
+   * @var string
+   */
+  protected static $base64;
+
+  /**
+   * Instância do Zip Handler.
+   *
+   * @var Handler
+   */
+  protected $handler;
+
+  protected function setUp()
   {
-    // Cria um arquivo qualquer em formato json
-    $data = [
-      'json' => 'test',
-    ];
+    $this->handler = new Handler();
 
-    $jsonString = json_encode($data, JSON_UNESCAPED_UNICODE);
-
-    // Cria o arquivo ZIP
-    $zip = new ZipArchive();
-
-    // Adiciona o arquivo JSON dentro do ZIP
-    if ($zip->open('test.zip', ZipArchive::CREATE) === true) {
-      $zip->addFromString('test.json', $jsonString);
-      $zip->close();
-    }
-
-    // Chama o handler
-    $handler = new Handler();
-
-    // Abre o arquivo ZIP
-    $handler->fromData(file_get_contents('test.zip'))->make();
-
-    // Remove o arquivo do disco
-    unlink('test.zip');
-
-    // Usa o primeiro arquivo
-
-    /**
-     * @var JsonFileFormat
-     */
-    $instance = $handler->use(0)->toFormat('application/json');
-
-    // Verifica se retornou a instância da classe Json
-    $this->assertTrue($instance instanceof JsonFileFormat);
-
-    // Verifica se o conteúdo do arquivo decodificado é igual ã entrada
-    $this->assertEquals($instance->getDecoded(), $data);
-  }
-
-  public function testJsonFromBase64()
-  {
-    // Cria um arquivo qualquer em formato json
-    $data = [
-      'json' => 'test',
-    ];
-
-    $jsonString = json_encode($data, JSON_UNESCAPED_UNICODE);
+    $jsonString = json_encode(['json' => 'test'], JSON_UNESCAPED_UNICODE);
 
     // Cria o arquivo ZIP
     $zip = new ZipArchive();
@@ -68,24 +38,27 @@ class Json extends TestCase
       $zip->close();
     }
 
-    // Transforma em base64 o conteúdo do test.zip
-    $base64 = base64_encode(file_get_contents('testb64.zip'));
 
+    // Transforma em base64 o conteúdo do test.zip
+    static::$base64 = base64_encode(file_get_contents('testb64.zip'));
+  }
+
+  protected function tearDown()
+  {
     // Remove o test.zip
     unlink('testb64.zip');
+  }
 
-    // Chama o handler
-    $handler = new Handler();
-
-    // Adiciona a entrada ao handler
+  public function testJsonFromBase64()
+  {
 
     /**
      * @var JsonFileFormat
      */
-    $instance = $handler
-      ->fromBase64($base64)
+    $instance = $this->handler
+      ->fromBase64(static::$base64)
       ->make()
-      ->use(0)
+      ->first()
       ->toFormat('application/json');
 
     // Verifica se existe a instância de JsonFileFormat
@@ -95,6 +68,6 @@ class Json extends TestCase
     $this->assertNotEmpty($instance->getDecoded());
 
     // E por último se o conteúdo foi corretamente retornado
-    $this->assertEquals($data, $instance->getDecoded());
+    $this->assertEquals(['json' => 'test'], $instance->getDecoded());
   }
 }


### PR DESCRIPTION
- Os métodos `make()` e `toFormat()` da classe `Handler` agora lançam `LogicException` quando não há nenhum arquivo selecionado.
- O método `use()` agora lança `OutOfRangeException` quando o índice selecionado é inexistente.
- Foram adicionados os métodos `first`, `last` e `exists` à classe `Handler`.
- Agora a classe `FileFormatFactory` conta com constantes de suporte para identificar tipos MIME.